### PR TITLE
fix/#30-dropdown박스 너비 수정

### DIFF
--- a/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
+++ b/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
@@ -55,7 +55,7 @@ fun KorailTalkDropdown(
 
     Box(
         modifier
-            .width(68.dp)
+            .width(75.dp)
             .zIndex(1f)
     ) {
         Column(

--- a/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
+++ b/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -30,6 +31,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -45,6 +52,15 @@ fun KorailTalkDropdown(
     modifier: Modifier = Modifier
 ) {
     var expanded by remember { mutableStateOf(false) }
+    val measurer = rememberTextMeasurer()
+
+    val textWidth = LocalDensity.current.run {
+        measurer.measure(
+            text = selectedItem,
+            style = KorailTalkTheme.typography.body.body2M15
+        ).size.width.toDp() + 36.dp
+    }
+
 
     // 화살표
     val rotateAngle by animateFloatAsState(
@@ -58,6 +74,7 @@ fun KorailTalkDropdown(
     ) {
         Column(
             Modifier
+                .width(textWidth)
                 .background(
                     color = KorailTalkTheme.colors.white,
                     shape = RoundedCornerShape(size = 4.dp)
@@ -70,8 +87,12 @@ fun KorailTalkDropdown(
         ) { //상단 선택된 아이템
             Row(
                 Modifier
+                    .fillMaxWidth()
                     .height(36.dp)
-                    .clickable { expanded = !expanded }
+                    .clickable {
+                        expanded = !expanded
+                        onItemSelected(items.first())
+                    }
                     .padding(horizontal = 8.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
@@ -96,15 +117,19 @@ fun KorailTalkDropdown(
             // 펼쳐졌을 때 나오는 리스트 영역
             if (expanded) {
                 val itemsToShow = items.drop(1)
-                HorizontalDivider(
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 8.dp),
-                    thickness = 1.dp,
-                    color = KorailTalkTheme.colors.gray100
-                )
 
-                LazyColumn {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    item {
+                        HorizontalDivider(
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 8.dp),
+                            thickness = 1.dp,
+                            color = KorailTalkTheme.colors.gray100
+                        )
+                    }
                     itemsIndexed(itemsToShow) { index, item ->
                         DropdownItem(
                             item = item,
@@ -154,15 +179,30 @@ fun DropdownItem(
             Text(
                 text = item,
                 color = KorailTalkTheme.colors.gray500,
-                style = KorailTalkTheme.typography.body.body2M15
+                style = KorailTalkTheme.typography.body.body2M15,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis // 영역 벗어났을 때 처리
             )
         }
+    }
+}
+
+@Composable
+fun rememberTextMeasurer(): TextMeasurer {
+    val fontFamilyResolver = LocalFontFamilyResolver.current
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+
+    return remember(fontFamilyResolver, density, layoutDirection) {
+        TextMeasurer(fontFamilyResolver, density, layoutDirection)
     }
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun KorailTalkDropdownPreview() {
+    val seatList = listOf("전체", "일반실", "특실")
+    val routeList = listOf("직통어쩌고", "환승저쩌고")
     var seatType by remember { mutableStateOf("전체") }
     var routeType by remember { mutableStateOf("직통") }
     Column(
@@ -175,13 +215,13 @@ private fun KorailTalkDropdownPreview() {
         ) {
             // 좌석 등급 드롭다운
             KorailTalkDropdown(
-                items = listOf("전체", "일반실", "특실"),
+                items = seatList,
                 selectedItem = seatType,
                 onItemSelected = { seatType = it }
             )
             // 운행 종류 드롭다운
             KorailTalkDropdown(
-                items = listOf("직통", "환승"),
+                items = routeList,
                 selectedItem = routeType,
                 onItemSelected = { routeType = it }
             )

--- a/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
+++ b/app/src/main/java/org/sopt/korailtalk/core/designsystem/component/dropdown/KorailTalkBasicDropDown.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -55,7 +54,6 @@ fun KorailTalkDropdown(
 
     Box(
         modifier
-            .width(75.dp)
             .zIndex(1f)
     ) {
         Column(
@@ -72,7 +70,6 @@ fun KorailTalkDropdown(
         ) { //상단 선택된 아이템
             Row(
                 Modifier
-                    .fillMaxWidth()
                     .height(36.dp)
                     .clickable { expanded = !expanded }
                     .padding(horizontal = 8.dp),


### PR DESCRIPTION
일반실을 누르면 옆 화살표가 작아지는 이슈가있어 너비 수정했습니다.

## 📮 관련 이슈
- closed #30

## 📌 작업 내용
- 일반실을 선택하면 화살표가 가려지는 이슈가 있었습니다. 박스 너비 68.dp->75.dp로 수정했습니다.
- ->가 아니고 내부 ` textWidth`계산, 텍스트 `Ellipsis` 처리로 수정했습니다.
-`dropdown` 펼쳤을 때 선택하면 선택한 항목이 나오는 게아니라 이전 항목이 보여 이부분도 수정했습니다(리드 나현이 만세) 

## 📸 스크린샷


https://github.com/user-attachments/assets/bc04e296-179d-4896-9265-151e2e9d6717



## 😅 미구현
- [ ] 

## 🫛 To. 리뷰어
-발견해주신 파트장님 ....샤라웃.......감사합니다 + 도움 주신 울 코레일톡 1조 만세1!
